### PR TITLE
Revamp ChannelCon EMEA guide into modern travel web app

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -206,6 +206,20 @@ body {
     box-shadow: 0 8px 25px rgba(5, 150, 105, 0.3);
 }
 
+.rate-callout {
+    background: white;
+    color: #1f2937;
+    padding: 1rem;
+    border-left: 4px solid var(--secondary-blue);
+    border-radius: var(--border-radius);
+    margin-top: 1rem;
+}
+
+.rate-note {
+    font-weight: 600;
+    margin: 0.5rem 0;
+}
+
 .savings-highlight {
     background: var(--gradient-danger);
     color: white;
@@ -217,6 +231,64 @@ body {
     font-size: 1.3rem;
     box-shadow: 0 8px 25px rgba(220, 38, 38, 0.3);
     border: 1px solid rgba(255,255,255,0.1);
+}
+
+.top-picks {
+    margin: 2rem 0;
+}
+
+.top-picks-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.top-picks-table th,
+.top-picks-table td {
+    border: 1px solid #e2e8f0;
+    padding: 0.75rem;
+    text-align: left;
+}
+
+.top-picks-table th {
+    background: #f8fafc;
+    font-weight: 600;
+}
+
+@media (max-width: 600px) {
+    .top-picks-table thead {
+        display: none;
+    }
+
+    .top-picks-table,
+    .top-picks-table tbody,
+    .top-picks-table tr,
+    .top-picks-table td {
+        display: block;
+        width: 100%;
+    }
+
+    .top-picks-table tr {
+        margin-bottom: 1rem;
+        border: 1px solid #e2e8f0;
+        border-radius: var(--border-radius);
+        overflow: hidden;
+    }
+
+    .top-picks-table td {
+        text-align: right;
+        padding-left: 50%;
+        position: relative;
+    }
+
+    .top-picks-table td::before {
+        content: attr(data-label);
+        position: absolute;
+        left: 0;
+        width: 50%;
+        padding-left: 0.75rem;
+        font-weight: 600;
+        text-align: left;
+    }
 }
 
 /* Event Highlights */
@@ -406,6 +478,18 @@ body {
     font-weight: bold;
 }
 
+.dutch-travel-tips {
+    background: #ecfdf5;
+    padding: 1.5rem;
+    border-left: 4px solid var(--accent-green);
+    border-radius: var(--border-radius);
+    margin: 2rem 0;
+}
+
+.dutch-travel-tips h4 {
+    margin-top: 0;
+}
+
 /* Hotel Grid */
 .hotel-grid {
     display: grid;
@@ -587,7 +671,8 @@ body {
 }
 
 .transport-icon {
-    font-size: 1.25rem;
+    width: 24px;
+    height: 24px;
     margin-right: 0.5rem;
 }
 
@@ -781,6 +866,20 @@ body {
     padding-top: 2rem;
     border-top: 2px solid #e2e8f0;
     font-weight: 500;
+}
+
+.site-footer {
+    text-align: center;
+    font-size: 0.85rem;
+    color: #64748b;
+    margin-top: 2rem;
+    padding: 1rem 0;
+    opacity: 0.7;
+}
+
+.site-footer a {
+    color: inherit;
+    text-decoration: none;
 }
 
 /* Animations */

--- a/img/icons/bus.svg
+++ b/img/icons/bus.svg
@@ -1,0 +1,25 @@
+<!--
+tags: [vehicle, drive, driver, engine, motor, journey, trip]
+category: Vehicles
+version: "1.7"
+unicode: "ebe4"
+-->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M6 17m-2 0a2 2 0 1 0 4 0a2 2 0 1 0 -4 0" />
+  <path d="M18 17m-2 0a2 2 0 1 0 4 0a2 2 0 1 0 -4 0" />
+  <path d="M4 17h-2v-11a1 1 0 0 1 1 -1h14a5 7 0 0 1 5 7v5h-2m-4 0h-8" />
+  <path d="M16 5l1.5 7l4.5 0" />
+  <path d="M2 10l15 0" />
+  <path d="M7 5l0 5" />
+  <path d="M12 5l0 5" />
+</svg>

--- a/img/icons/robot.svg
+++ b/img/icons/robot.svg
@@ -1,0 +1,27 @@
+<!--
+category: Games
+tags: [technology, ai, machine, bot, android]
+version: "1.53"
+unicode: "f00b"
+-->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M6 4m0 2a2 2 0 0 1 2 -2h8a2 2 0 0 1 2 2v4a2 2 0 0 1 -2 2h-8a2 2 0 0 1 -2 -2z" />
+  <path d="M12 2v2" />
+  <path d="M9 12v9" />
+  <path d="M15 12v9" />
+  <path d="M5 16l4 -2" />
+  <path d="M15 14l4 2" />
+  <path d="M9 18h6" />
+  <path d="M10 8v.01" />
+  <path d="M14 8v.01" />
+</svg>

--- a/img/icons/sunrise.svg
+++ b/img/icons/sunrise.svg
@@ -1,0 +1,21 @@
+<!--
+tags: [west, horizon, landscape, evening]
+category: Weather
+version: "1.10"
+unicode: "ef1c"
+-->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M3 17h1m16 0h1m-15.4 -6.4l.7 .7m12.1 -.7l-.7 .7m-9.7 5.7a4 4 0 0 1 8 0" />
+  <path d="M3 21l18 0" />
+  <path d="M12 9v-6l3 3m-6 0l3 -3" />
+</svg>

--- a/img/icons/train.svg
+++ b/img/icons/train.svg
@@ -1,0 +1,25 @@
+<!--
+tags: [railway, rails, tgv, journey, travel, network, route, passenger]
+category: Vehicles
+version: "1.34"
+unicode: "ed96"
+-->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M21 13c0 -3.87 -3.37 -7 -10 -7h-8" />
+  <path d="M3 15h16a2 2 0 0 0 2 -2" />
+  <path d="M3 6v5h17.5" />
+  <path d="M3 11v4" />
+  <path d="M8 11v-5" />
+  <path d="M13 11v-4.5" />
+  <path d="M3 19h18" />
+</svg>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>ChannelCon EMEA 2025 - Accommodation Guide | GTIA</title>
+    <title>ChannelCon EMEA 2025 – Travel &amp; Stay Playbook | GTIA</title>
     
     <!-- SEO Meta Tags -->
     <meta name="description" content="Professional accommodation guide for ChannelCon EMEA 2025 attendees. Find cost-effective hotel alternatives to Sofitel Heathrow T5 with transportation info and GTIA negotiated rates.">
@@ -28,6 +28,7 @@
     <!-- External Stylesheets -->
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="css/styles.css">
+    <script defer data-domain="channelcon-emea-2025.vercel.app" src="https://plausible.io/js/script.js"></script>
     
     <!-- Structured Data -->
     <script type="application/ld+json">
@@ -65,8 +66,8 @@
         <div class="header">
             <div class="header-content">
                 <h1>ChannelCon EMEA 2025</h1>
-                <div class="subtitle">Accommodation Guide & Travel Information</div>
-                <div class="gtia-brand">Powered by Tycho Löke someone who has too much time on his hands</div>
+                <div class="subtitle">Your Travel &amp; Stay Playbook</div>
+                <div class="gtia-brand">Curated by Tycho Löke—driven by precision</div>
             </div>
         </div>
         
@@ -91,18 +92,21 @@
                 
                 <div style="text-align: center; margin-top: 2rem;">
                     <a href="https://channelcon.gtia.org/emea" target="_blank" rel="noopener" class="cta-button primary">
-                        🎟️ Register for ChannelCon EMEA
+                        🎟️ Secure Your Spot
                     </a>
                     <a href="https://channelcon.gtia.org/emea" target="_blank" rel="noopener" class="cta-button secondary">
-                        📋 View Full Event Details
+                        📋 Plan Your Trip
                     </a>
                 </div>
             </div>
 
             <div class="gtia-rates">
                 <h3 style="margin-top: 0;">🏆 GTIA Negotiated Rates Available</h3>
-                <p><strong>GTIA has secured a limited number of rooms at £189.00*</strong><br>
-                <small>*Inclusive of breakfast, exclusive of VAT | Available to GTIA members and ChannelCon EMEA attendees</small></p>
+                <div class="rate-callout">
+                    <p><strong>GTIA has secured a limited number of rooms at £189.00*</strong></p>
+                    <p class="rate-note">GTIA-negotiated Sofitel rate: £189/night (you save £100+ vs. market rate)</p>
+                    <small>*Inclusive of breakfast, exclusive of VAT | Available to GTIA members and ChannelCon EMEA attendees</small>
+                </div>
             </div>
 
             <div class="savings-highlight">
@@ -157,7 +161,41 @@
             </div>
 
             <h2 class="section-header">💰 Current Pricing & Availability (October 12-15, 2025)</h2>
-            
+
+            <div class="top-picks">
+                <h3>Top Picks at a Glance</h3>
+                <table class="top-picks-table">
+                    <thead>
+                        <tr>
+                            <th>Option</th>
+                            <th>Price</th>
+                            <th>Best For</th>
+                            <th>Transport Perks</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td data-label="Option">Sofitel T5</td>
+                            <td data-label="Price">£189 (GTIA)</td>
+                            <td data-label="Best For">Premium comfort + breakfast</td>
+                            <td data-label="Transport Perks">Connected via Heathrow Express</td>
+                        </tr>
+                        <tr>
+                            <td data-label="Option">Thistle T5</td>
+                            <td data-label="Price">£82–136</td>
+                            <td data-label="Best For">Affordable + "Pod service" novelty</td>
+                            <td data-label="Transport Perks">Driverless capsules</td>
+                        </tr>
+                        <tr>
+                            <td data-label="Option">Premier Inn T4</td>
+                            <td data-label="Price">~£70</td>
+                            <td data-label="Best For">Budget choice</td>
+                            <td data-label="Transport Perks">Shuttle access</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+
             <div class="pricing-overview">
                 <h3>📊 Price Ranges for ChannelCon EMEA Dates</h3>
                 <div class="price-grid">
@@ -189,8 +227,17 @@
                     <li><strong>Book Early:</strong> ChannelCon EMEA is a major industry event - rooms fill up quickly</li>
                     <li><strong>GTIA Members:</strong> Secure the £189 Sofitel rate through official channels</li>
                     <li><strong>Flexible Dates:</strong> Consider arriving October 11th or staying until October 16th for better rates</li>
+                    <li><strong>Optimal Window:</strong> Try booking between October 11–16 for better availability and rates</li>
                     <li><strong>Package Deals:</strong> Many hotels offer parking + accommodation bundles</li>
                     <li><strong>Cancellation Policies:</strong> Book refundable rates when possible given event schedules</li>
+                </ul>
+            </div>
+
+            <div class="dutch-travel-tips">
+                <h4>🇳🇱 For Dutch Attendees</h4>
+                <ul>
+                    <li>Fly from Amsterdam Schiphol to Heathrow; consider NS International + Heathrow Express for a seamless transfer.</li>
+                    <li>Most hotel websites support euro pricing and Dutch language options.</li>
                 </ul>
             </div>
 
@@ -205,28 +252,28 @@
                 <div class="transport-grid">
                     <div class="transport-item">
                         <div class="transport-header">
-                            <span class="transport-icon">🚇</span>
+                            <img src="img/icons/train.svg" alt="Train" class="transport-icon">
                             <strong>Inter-Terminal Connections</strong>
                         </div>
                         <p>Free Heathrow Express and Underground trains connect all terminals every 15 minutes</p>
                     </div>
                     <div class="transport-item">
                         <div class="transport-header">
-                            <span class="transport-icon">🌅</span>
+                            <img src="img/icons/sunrise.svg" alt="Sunrise" class="transport-icon">
                             <strong>Early Morning Service</strong>
                         </div>
                         <p>Buses run between terminals from 3:51 AM for early departures and late arrivals</p>
                     </div>
                     <div class="transport-item">
                         <div class="transport-header">
-                            <span class="transport-icon">🚌</span>
+                            <img src="img/icons/bus.svg" alt="Bus" class="transport-icon">
                             <strong>Hoppa Bus Service</strong>
                         </div>
                         <p>Airport-operated shuttle buses connect most hotels to all terminals (£6.80 one way)</p>
                     </div>
                     <div class="transport-item">
                         <div class="transport-header">
-                            <span class="transport-icon">🚁</span>
+                            <img src="img/icons/robot.svg" alt="Driverless pod" class="transport-icon">
                             <strong>Pod Service (Unique)</strong>
                         </div>
                         <p>Exclusive to Thistle T5 - automated driverless capsules directly to Terminal 5</p>
@@ -254,6 +301,10 @@
             </div>
         </div>
     </div>
+
+    <footer class="site-footer">
+        <small>&copy; 2025 <a href="https://abovethestack.com" target="_blank" rel="noopener">AboveTheStack.com</a></small>
+    </footer>
 
     <!-- Transport Modal -->
     <div id="transportModal" class="modal-overlay" role="dialog" aria-labelledby="modalHotelName" aria-hidden="true">


### PR DESCRIPTION
## Summary
- Refine tone and calls-to-action for a more confident, action-oriented landing experience
- Highlight GTIA savings and add a quick-scan table summarizing top accommodation picks
- Introduce accessible SVG transport icons, Dutch attendee tips, footer branding, and Plausible analytics

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac3f787a448327bba37821eba67f2d